### PR TITLE
Action name format

### DIFF
--- a/Demo/Client/Shared/Notifications.razor
+++ b/Demo/Client/Shared/Notifications.razor
@@ -9,7 +9,7 @@
                     <small class="col text-white">@message.Time</small>
                     <button type="button" class="btn-close" @onclick="()=>{ _notifications.Remove(message); }"></button>
                 </div>
-                <strong class="text-white px-0">@FormatSource(message)</strong>
+                <strong class="text-white px-0">@message.Source.GetActionFriendlyName(0)</strong>
             </div>
             <div class="toast-body">
                 @message.Content
@@ -87,12 +87,5 @@
             default:
                 return "bg-danger";
         }
-    }
-
-    private string FormatSource(Notification notification)
-    {
-        return notification.Type == NotificationType.ActionError
-            ? notification.Source.GetActionFriendlyName(0)
-            : notification.Source;
     }
 }

--- a/Demo/Client/Shared/Notifications.razor
+++ b/Demo/Client/Shared/Notifications.razor
@@ -1,4 +1,5 @@
-﻿@using Pipaslot.Mediator.Notifications
+﻿@using Pipaslot.Mediator.Abstractions;
+ @using Pipaslot.Mediator.Notifications
 <div class="toast-container position-fixed top-0 end-0" style="z-index: 11">
     @foreach (var message in _notifications)
     {
@@ -8,7 +9,7 @@
                     <small class="col text-white">@message.Time</small>
                     <button type="button" class="btn-close" @onclick="()=>{ _notifications.Remove(message); }"></button>
                 </div>
-                <strong class="text-white px-0">@message.Source</strong>
+                <strong class="text-white px-0">@FormatSource(message)</strong>
             </div>
             <div class="toast-body">
                 @message.Content
@@ -86,5 +87,12 @@
             default:
                 return "bg-danger";
         }
+    }
+
+    private string FormatSource(Notification notification)
+    {
+        return notification.Type == NotificationType.ActionError
+            ? notification.Source.GetActionFriendlyName(0)
+            : notification.Source;
     }
 }

--- a/Demo/Client/Shared/Notifications.razor
+++ b/Demo/Client/Shared/Notifications.razor
@@ -9,7 +9,7 @@
                     <small class="col text-white">@message.Time</small>
                     <button type="button" class="btn-close" @onclick="()=>{ _notifications.Remove(message); }"></button>
                 </div>
-                <strong class="text-white px-0">@message.Source.GetActionFriendlyName(0)</strong>
+                <strong class="text-white px-0">@message.Source</strong>
             </div>
             <div class="toast-body">
                 @message.Content

--- a/Demo/Server/MediatorMiddlewares/CustomLoggingMiddleware.cs
+++ b/Demo/Server/MediatorMiddlewares/CustomLoggingMiddleware.cs
@@ -1,0 +1,42 @@
+﻿using Pipaslot.Mediator.Abstractions;
+using Pipaslot.Mediator.Middlewares;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Demo.Server.MediatorMiddlewares
+{
+    public class CustomLoggingMiddleware : IMediatorMiddleware
+    {
+        private readonly ILogger _logger;
+        private readonly static JsonSerializerOptions _serializationOptions = new()
+        {
+            PropertyNamingPolicy = null
+        };
+
+        public CustomLoggingMiddleware(ILogger<CustomLoggingMiddleware> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task Invoke(MediatorContext context, MiddlewareDelegate next)
+        {
+            // Prevent ActionErrors logged from exceptions in execution middleware
+            // Catch all exceptions and provide only unified message
+            try
+            {
+                context.IgnoreActionErrors = true;
+                await next(context);
+            }
+            catch (Exception c) when (c is TaskCanceledException || c is OperationCanceledException)
+            {
+                context.Status = ExecutionStatus.Failed;
+                // No error message is needed
+            }
+            catch (Exception e)
+            {
+                context.AddError("Operation failed, please contact administrator", "CustomLogging of action: " + context.Action.GetActionFriendlyName());
+                _logger.LogError(e, @$"Exception occured during Mediator execution for action '{context.ActionIdentifier}' with message: '{e.Message}'.");
+            }
+        }
+    }
+}

--- a/Demo/Server/Program.cs
+++ b/Demo/Server/Program.cs
@@ -9,7 +9,6 @@ using Pipaslot.Mediator;
 using Pipaslot.Mediator.Http;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Windows.Input;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;

--- a/Demo/Server/Program.cs
+++ b/Demo/Server/Program.cs
@@ -9,6 +9,7 @@ using Pipaslot.Mediator;
 using Pipaslot.Mediator.Http;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Windows.Input;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -38,7 +39,7 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 ValidIssuer = authOptions.Issuer,
                 ValidAudience = authOptions.Audience,
                 IssuerSigningKey = LoginRequestHandler.CreateSymetricKey(authOptions.SecretKey),
-                
+
             };
     });
 
@@ -51,7 +52,11 @@ services.AddMediatorServer(o =>
 })
     .AddActionsFromAssemblyOf<WeatherForecast.Request>()
     .AddHandlersFromAssemblyOf<WheatherForecastRequestHandler>()
-    .UseExceptionLogging()                  // Log all unhalded exception via ILogger
+    // Log all unhalded exception via ILogger. Wont catch exception from IMessage as the next middleware provides custom handling for the Messages
+    .UseExceptionLogging()                  
+    .UseWhenAction<IMessage>(
+        p => p.Use<CustomLoggingMiddleware>()
+        )
     // Configure pipelines for own custom action types. This is CQRS implementaiton Demo 
     //.UseWhen<IQuery>(s => s               // Pipeline specified only for queries
     //    .Use<QuerySpecificMiddleware>()   // Middleare which should be applied only to Queries

--- a/Demo/Shared/IInternalRequest.cs
+++ b/Demo/Shared/IInternalRequest.cs
@@ -3,14 +3,10 @@ using Pipaslot.Mediator.Authorization;
 
 namespace Demo.Shared
 {
-    [AnonymousPolicy] ///Isalways anonymous as it is protected by DirectHttpCallProtectionMiddleware 
-    public abstract class BaseInternalRequest<T> : IInternalRequest<T>
-    {
-
-    }
     /// <summary>
     /// Request which we want to protect agains direct calls from API as it may return sensitive data available on backed but forbidden to be transfered from the backend to frontend.
     /// </summary>
+    [AnonymousPolicy] ///Is always anonymous as it is protected by DirectHttpCallProtectionMiddleware 
     public interface IInternalRequest<out T> : IMediatorAction<T>, IInternalRequest
     {
     }

--- a/Demo/Shared/Playground/CustomInternalRequest.cs
+++ b/Demo/Shared/Playground/CustomInternalRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Demo.Shared.Playground
 {
-    public class CustomInternalRequest : BaseInternalRequest<bool>
+    public class CustomInternalRequest : IInternalRequest<bool>
     {
     }
 }

--- a/Pipaslot.Mediator.Http/Middlewares/ExceptionLoggingMiddleware.cs
+++ b/Pipaslot.Mediator.Http/Middlewares/ExceptionLoggingMiddleware.cs
@@ -25,6 +25,12 @@ namespace Pipaslot.Mediator.Http.Middlewares
             {
                 await next(context);
             }
+            catch (TaskCanceledException oce)
+            {
+                var serializedData = Serialize(context.Action);
+                _logger.LogWarning(oce, $"Action {context.ActionIdentifier} was canceled. Action content: {serializedData}");
+                throw;
+            }
             catch (OperationCanceledException oce)
             {
                 var serializedData = Serialize(context.Action);

--- a/Pipaslot.Mediator.Http/Pipaslot.Mediator.Http.csproj
+++ b/Pipaslot.Mediator.Http/Pipaslot.Mediator.Http.csproj
@@ -15,7 +15,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Nullable>enable</Nullable>
-		<LangVersion>9</LangVersion>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Pipaslot.Mediator/Abstractions/MediatorActionExtensions.cs
+++ b/Pipaslot.Mediator/Abstractions/MediatorActionExtensions.cs
@@ -1,10 +1,62 @@
-﻿namespace Pipaslot.Mediator.Abstractions
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Pipaslot.Mediator.Abstractions
 {
-    internal static class MediatorActionExtensions
+    public static class MediatorActionExtensions
     {
-        public static string GetActionName(this IMediatorAction action)
+        internal static string GetActionName(this IMediatorAction? action)
         {
-            return action.GetType().ToString();
+            return action?.GetType()?.ToString() ?? string.Empty;
+        }
+        /// <summary>
+        /// Returns User friendly formated name. For examply class type "MyApp.GetUserListAction" will be formated as "Get user list"
+        /// </summary>
+        public static string GetActionFriendlyName(this IMediatorAction action, int ignoreLastWords = 1)
+        {
+            var name = action.GetActionName();
+            return GetActionFriendlyName(name, ignoreLastWords);
+        }
+
+        public static string GetActionFriendlyName(this string actionName, int ignoreLastWords = 1)
+        {
+            if(string.IsNullOrWhiteSpace(actionName))
+            {
+                return string.Empty;
+            }
+            var lastNamespaceDot = actionName.LastIndexOf('.');
+            var startIndex = lastNamespaceDot < 0
+                ? 0
+                : lastNamespaceDot + 1;
+            var className = actionName.Substring(startIndex);
+            var cased = Regex.Replace(className, "([a-z0-9])([A-Z]*)([A-Z])", FormatUpercases);
+            var noUnd = Regex.Replace(cased, "[_\\+]([A-Za-z0-9])", FormatUnderline);
+            var split = noUnd.Split(' ');
+            var relevant = split.Take(split.Count() - ignoreLastWords);
+            return string.Join(" ", relevant);
+        }
+
+        private static string FormatUnderline(Match match)
+        {
+            return $" {match.Groups[1].Value.ToLower()}";
+        }
+
+        private static string FormatUpercases(Match match)
+        {
+            var sb = new StringBuilder();
+            sb.Append(match.Groups[1].Value);
+            sb.Append(" ");
+            if (match.Groups[2].Value.Length > 0)
+            {
+                sb.Append(match.Groups[2].Value);
+                sb.Append(" ");
+            }
+            sb.Append(match.Groups[3].Value.ToLower());
+
+            return sb.ToString();
         }
     }
 }

--- a/Pipaslot.Mediator/Authorization/AnonymousPolicyAttribute.cs
+++ b/Pipaslot.Mediator/Authorization/AnonymousPolicyAttribute.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Pipaslot.Mediator.Authorization
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public class AnonymousPolicyAttribute : Attribute, IPolicy
     {
         public async Task<RuleSet> Resolve(IServiceProvider services, CancellationToken cancellationToken)

--- a/Pipaslot.Mediator/Authorization/AuthenticatedPolicyAttribute.cs
+++ b/Pipaslot.Mediator/Authorization/AuthenticatedPolicyAttribute.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Pipaslot.Mediator.Authorization
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public class AuthenticatedPolicyAttribute : Attribute, IPolicy
     {
         public async Task<RuleSet> Resolve(IServiceProvider services, CancellationToken cancellationToken)

--- a/Pipaslot.Mediator/Authorization/PolicyResolver.cs
+++ b/Pipaslot.Mediator/Authorization/PolicyResolver.cs
@@ -158,6 +158,9 @@ namespace Pipaslot.Mediator.Authorization
 
         private static IPolicy[] GetPolicyAttributes(Type type) => type
                 .GetCustomAttributes(true)
+                .Union(type
+                    .GetInterfaces()
+                    .SelectMany(i => i.GetCustomAttributes(true)))
                 .Where(a => a is IPolicy)
                 .Cast<IPolicy>()
                 .ToArray();

--- a/Pipaslot.Mediator/Authorization/RolePolicyAttribute.cs
+++ b/Pipaslot.Mediator/Authorization/RolePolicyAttribute.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Pipaslot.Mediator.Authorization
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public class RolePolicyAttribute : Attribute, IPolicy
     {
         private readonly IdentityPolicy _policy;

--- a/Pipaslot.Mediator/Notifications/Notification.cs
+++ b/Pipaslot.Mediator/Notifications/Notification.cs
@@ -39,7 +39,7 @@ namespace Pipaslot.Mediator.Notifications
             {
                 Type = NotificationType.ActionError,
                 Content = content,
-                Source = action?.GetType()?.ToString() ?? ""
+                Source = action.GetActionName()
             };
         }
 
@@ -49,7 +49,7 @@ namespace Pipaslot.Mediator.Notifications
             {
                 Type = NotificationType.Error,
                 Content = content,
-                Source = action?.GetType()?.ToString() ?? ""
+                Source = action.GetActionName()
             };
         }
 

--- a/Pipaslot.Mediator/Notifications/Notification.cs
+++ b/Pipaslot.Mediator/Notifications/Notification.cs
@@ -7,6 +7,10 @@ namespace Pipaslot.Mediator.Notifications
     public class Notification : IEquatable<Notification?>
     {
         public DateTime Time { get; set; } = DateTime.Now;
+        /// <summary>
+        /// Name of action for which the notification was raised.
+        /// Can be also used as title.
+        /// </summary>
         public string Source { get; set; } = "";
         public string Content { get; set; } = "";
         public NotificationType Type { get; set; } = NotificationType.Information;

--- a/Pipaslot.Mediator/Notifications/NotificationType.cs
+++ b/Pipaslot.Mediator/Notifications/NotificationType.cs
@@ -1,27 +1,32 @@
-﻿namespace Pipaslot.Mediator.Notifications
+﻿using System;
+
+namespace Pipaslot.Mediator.Notifications
 {
     public enum NotificationType
     {
+        // TODO COnsider to get rid of this notification type from the app and let the responsibility of exception handling to consumer.
+        // TODO Consider to add new type "Trace" for detailed notifications which may be interrested for troubleshooting by users
         /// <summary>
         /// Error produced by mediator during action processing in handler
         /// </summary>
-        ActionError,
+        [Obsolete]
+        ActionError = 0,
         /// <summary>
         /// Custom type provided by application or by middlewares
         /// </summary>
-        Success,
+        Success = 1,
         /// <summary>
         /// Custom type provided by application or by middlewares
         /// </summary>
-        Information,
+        Information = 2,
         /// <summary>
         /// Custom type provided by application or by middlewares
         /// </summary>
-        Warning,
+        Warning = 3,
         /// <summary>
         /// Custom type provided by application or by middlewares
         /// </summary>
-        Error
+        Error = 4
     }
 
     public static class NotificationTypeExtensions

--- a/Pipaslot.Mediator/Pipaslot.Mediator.csproj
+++ b/Pipaslot.Mediator/Pipaslot.Mediator.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
-		<LangVersion>9</LangVersion>
+		<LangVersion>11</LangVersion>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Version>6.4.0</Version>

--- a/tests/Pipaslot.Mediator.Tests/Abstractions/MediatorActionExtensionsTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Abstractions/MediatorActionExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿using Pipaslot.Mediator.Abstractions;
+
+namespace Pipaslot.Mediator.Tests.Abstractions
+{
+    public class MediatorActionExtensionsTests
+    {
+        [Theory]
+        [InlineData(-1, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university I love action")]
+        [InlineData(0, null, "")]
+        [InlineData(0, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university I love action")]
+        [InlineData(0, "Rude.Dude.TheMITUniversityILove+Action", "The MIT university I love action")]
+        [InlineData(0, "TheMITUniversityILove_Action"          , "The MIT university I love action")]
+        [InlineData(1, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university I love")]
+        [InlineData(2, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university I")]
+        [InlineData(3, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university")]
+        [InlineData(4, "Rude.Dude.TheMITUniversityILove_Action", "The MIT")]
+        [InlineData(5, "Rude.Dude.TheMITUniversityILove_Action", "The")]
+        [InlineData(6, "Rude.Dude.TheMITUniversityILove_Action", "")]
+        [InlineData(7, "Rude.Dude.TheMITUniversityILove_Action", "")]
+        public void GetActionFriendlyName_WithoutLastWord(int ignoredLastWords, string source, string expected)
+        {
+            var name = source.GetActionFriendlyName(ignoredLastWords);
+            Assert.Equal(expected, name);
+        }
+    }
+}

--- a/tests/Pipaslot.Mediator.Tests/Abstractions/MediatorActionExtensionsTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Abstractions/MediatorActionExtensionsTests.cs
@@ -11,6 +11,7 @@ namespace Pipaslot.Mediator.Tests.Abstractions
         [InlineData(0, "Rude.Dude.TheMITUniversityILove+Action", "The MIT university I love action")]
         [InlineData(0, "TheMITUniversityILove_Action"          , "The MIT university I love action")]
         [InlineData(1, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university I love")]
+        [InlineData(1, "Rude.Dude.TheMITUniversityILove+Action", "The MIT university I love")]
         [InlineData(2, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university I")]
         [InlineData(3, "Rude.Dude.TheMITUniversityILove_Action", "The MIT university")]
         [InlineData(4, "Rude.Dude.TheMITUniversityILove_Action", "The MIT")]

--- a/tests/Pipaslot.Mediator.Tests/Authorization/PolicyResolverTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Authorization/PolicyResolverTests.cs
@@ -70,6 +70,12 @@ namespace Pipaslot.Mediator.Tests.Authorization
                 new NoAuthorizationHandlerAuthorizationAsyncHandler());
 
         [Fact]
+        public async Task GetPolicies_ReadPolicyFromInterfaces() => await RunGetPolicies(
+                new AnonamousAction(),
+                1);
+
+
+        [Fact]
         public async Task CheckPolicies_AuthorizedActionAndSyncAndAsyncHandlersAndUnauthorizedHandler_ThrowException() => await RunCheckPolicies(
                 new ActionAuthorizedByAttr(),
                 AuthorizationException.UnauthorizedHandlerCode,
@@ -97,6 +103,10 @@ namespace Pipaslot.Mediator.Tests.Authorization
         private class NoAuthorization : IMediatorAction { }
         [AnonymousPolicy]
         private class NoAuthorizationHandlerAttribute { }
+
+        [AnonymousPolicy]
+        private interface IAnonamousAction : IMediatorAction { }
+        private class AnonamousAction : IAnonamousAction { }
         private class NoAuthorizationHandler : IMediatorHandler<IMediatorAction>
         {
             public Task Handle(IMediatorAction action, CancellationToken cancellationToken)


### PR DESCRIPTION
- Added a helper for formatting action names to friendly format `Pipaslot.Mediator.Abstractions.MediatorActionExtensions.GetActionFriendlyName`
- Added workaround on MediatorContext for ignoring ActionError notification types
- Allow policy attributes to be defined on interfaces