### PR TITLE
Remove unused dependency and enhance Rule serialization

### DIFF
--- a/Pipaslot.Mediator.Http/Pipaslot.Mediator.Http.csproj
+++ b/Pipaslot.Mediator.Http/Pipaslot.Mediator.Http.csproj
@@ -27,31 +27,26 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="System.Text.Json" Version="6.0.10"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="System.Text.Json" Version="9.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="System.Text.Json" Version="10.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1"/>
     </ItemGroup>
 

--- a/Pipaslot.Mediator/Authorization/Rule.cs
+++ b/Pipaslot.Mediator/Authorization/Rule.cs
@@ -13,7 +13,7 @@ public class Rule : IPolicy
     /// <summary>
     /// Default rule that is always evaluated as <see cref="AccessType.Deny"/> when not combined with other other rules
     /// </summary>
-    public static Rule Default = new (RuleOutcome.Ignored, string.Empty);
+    public static readonly Rule Default = new (RuleOutcome.Ignored, string.Empty);
     
     public RuleScope Scope { get; }
 

--- a/Pipaslot.Mediator/Authorization/Rule.cs
+++ b/Pipaslot.Mediator/Authorization/Rule.cs
@@ -10,9 +10,14 @@ namespace Pipaslot.Mediator.Authorization;
 /// </summary>
 public class Rule : IPolicy
 {
-    public RuleScope Scope { get; } = RuleScope.State;
+    /// <summary>
+    /// Default rule that is always evaluated as <see cref="AccessType.Deny"/> when not combined with other other rules
+    /// </summary>
+    public static Rule Default = new (RuleOutcome.Ignored, string.Empty);
+    
+    public RuleScope Scope { get; }
 
-    public RuleOutcome Outcome { get; } = RuleOutcome.Deny;
+    public RuleOutcome Outcome { get; }
 
     /// <summary>
     /// Default rule name if not specified. It is used in cases where the value should serve as a sentence or when we want to prevent additional formatting.

--- a/Pipaslot.Mediator/Authorization/Rule.cs
+++ b/Pipaslot.Mediator/Authorization/Rule.cs
@@ -169,4 +169,9 @@ public class Rule : IPolicy
     {
         return new RuleSet(Operator.Or, [rule1, rule2]);
     }
+
+    public static implicit operator RuleSet(Rule rule)
+    {
+        return new RuleSet(rule);
+    }
 }

--- a/Pipaslot.Mediator/Authorization/Rule.cs
+++ b/Pipaslot.Mediator/Authorization/Rule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -38,7 +39,8 @@ public class Rule : IPolicy
     internal Rule(RuleOutcome outcome, string value) : this(DefaultName, value, outcome)
     {
     }
-
+    
+    [JsonConstructor]
     public Rule(string name, string value, RuleOutcome outcome = RuleOutcome.Deny, RuleScope scope = RuleScope.State)
     {
         Name = name;

--- a/Pipaslot.Mediator/Authorization/RuleSet.cs
+++ b/Pipaslot.Mediator/Authorization/RuleSet.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +15,9 @@ namespace Pipaslot.Mediator.Authorization;
 /// </summary>
 public class RuleSet : IPolicy
 {
+    /// <inheritdoc cref="Rule.Default"/>
+    public static readonly RuleSet Default = new (Rule.Default);
+
     public Operator Operator { get; }
     public List<Rule> Rules { get; set; } = [];
     public List<RuleSet> RuleSets { get; set; } = [];
@@ -27,6 +31,7 @@ public class RuleSet : IPolicy
     {
     }
 
+    [JsonConstructor]
     public RuleSet(Operator @operator)
     {
         Operator = @operator;

--- a/tests/Pipaslot.Mediator.Tests/Authorization/RuleSetSerializationTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Authorization/RuleSetSerializationTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Pipaslot.Mediator.Authorization;
+
+namespace Pipaslot.Mediator.Tests.Authorization;
+
+public class RuleSetSerializationTests
+{
+    [Fact]
+    public void RuleSet_RoundtripSerialization_RestoresEntireState()
+    {
+        // Arrange: create a complex structure with nested RuleSets and various Rules
+        var root = new RuleSet(Operator.Or, [
+            // First child: Add with two different rules
+            new RuleSet(Operator.Add, [
+                new Rule(name: "Role", value: "Admin", outcome: RuleOutcome.Allow, scope: RuleScope.Identity),
+                new Rule(name: "Claim", value: "CanEdit", outcome: RuleOutcome.Deny, scope: RuleScope.State)
+            ]),
+
+            // Second child: And with nested Or set inside
+            new RuleSet(Operator.And, [
+                new RuleSet(Operator.Or, [
+                    new Rule(name: "Feature", value: "ExperimentalX", outcome: RuleOutcome.Unavailable, scope: RuleScope.State),
+                    new Rule(name: "Toggle", value: "Beta", outcome: RuleOutcome.Ignored, scope: RuleScope.Identity)
+                ])
+            ])
+        ]);
+
+        // Act: serialize and then deserialize using a converter for Rule
+        var json = JsonSerializer.Serialize(root);
+        var clone = JsonSerializer.Deserialize<RuleSet>(json)!;
+
+        // Assert: entire state is restored (operators, rules, and all rule properties)
+        AssertRuleSetEqual(root, clone);
+    }
+
+    private static void AssertRuleSetEqual(RuleSet expected, RuleSet actual)
+    {
+        Assert.Equal(expected.Operator, actual.Operator);
+
+        // Compare rules in order
+        Assert.Equal(expected.Rules.Count, actual.Rules.Count);
+        for (var i = 0; i < expected.Rules.Count; i++)
+        {
+            var er = expected.Rules[i];
+            var ar = actual.Rules[i];
+            Assert.Equal(er.Name, ar.Name);
+            Assert.Equal(er.Value, ar.Value);
+            Assert.Equal(er.Scope, ar.Scope);
+            Assert.Equal(er.Outcome, ar.Outcome);
+        }
+
+        // Compare child rule sets recursively in order
+        Assert.Equal(expected.RuleSets.Count, actual.RuleSets.Count);
+        for (var i = 0; i < expected.RuleSets.Count; i++)
+        {
+            AssertRuleSetEqual(expected.RuleSets[i], actual.RuleSets[i]);
+        }
+    }
+}

--- a/tests/Pipaslot.Mediator.Tests/Authorization/RuleTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Authorization/RuleTests.cs
@@ -7,8 +7,7 @@ public class RuleTests
     [Fact]
     public void Default_IsReducedToDeny()
     {
-        var set = new RuleSet(Rule.Default);
-        AssertAccessType(set, AccessType.Deny);
+        AssertAccessType(Rule.Default, AccessType.Deny);
     }
     
     [Theory]

--- a/tests/Pipaslot.Mediator.Tests/Authorization/RuleTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Authorization/RuleTests.cs
@@ -1,0 +1,53 @@
+using Pipaslot.Mediator.Authorization;
+
+namespace Pipaslot.Mediator.Tests.Authorization;
+
+public class RuleTests
+{
+    [Fact]
+    public void Default_IsReducedToDeny()
+    {
+        var set = new RuleSet(Rule.Default);
+        AssertAccessType(set, AccessType.Deny);
+    }
+    
+    [Theory]
+    [InlineData(RuleOutcome.Allow, AccessType.Deny)]
+    [InlineData(RuleOutcome.Deny, AccessType.Deny)]
+    [InlineData(RuleOutcome.Unavailable, AccessType.Unavailable)]
+    [InlineData(RuleOutcome.Ignored, AccessType.Deny)]
+    public void Default_CombinedWithAnd(RuleOutcome outcome, AccessType expected)
+    {
+        var set = Rule.Default & new Rule(outcome, string.Empty);
+        AssertAccessType(set, expected);
+    }
+    
+    [Theory]
+    [InlineData(RuleOutcome.Allow, AccessType.Allow)]
+    [InlineData(RuleOutcome.Deny, AccessType.Deny)]
+    [InlineData(RuleOutcome.Unavailable, AccessType.Unavailable)]
+    [InlineData(RuleOutcome.Ignored, AccessType.Deny)]
+    public void Default_CombinedWithAdd(RuleOutcome outcome, AccessType expected)
+    {
+        var set = Rule.Default + new Rule(outcome, string.Empty);
+        AssertAccessType(set, expected);
+    }
+    
+    [Theory]
+    [InlineData(RuleOutcome.Allow, AccessType.Allow)]
+    [InlineData(RuleOutcome.Deny, AccessType.Deny)]
+    [InlineData(RuleOutcome.Unavailable, AccessType.Unavailable)]
+    [InlineData(RuleOutcome.Ignored, AccessType.Deny)]
+    public void Default_CombinedWithOr(RuleOutcome outcome, AccessType expected)
+    {
+        var set = Rule.Default | new Rule(outcome, string.Empty);
+        AssertAccessType(set, expected);
+    }
+
+    private void AssertAccessType(RuleSet set, AccessType expected)
+    {
+        var node = set.Reduce();
+        var accessType = node.Outcome.ToAccessType();
+        Assert.Equal(expected, accessType);
+    }
+}


### PR DESCRIPTION
### Summary

This pull request includes the following changes:
- Removed the unnecessary `System.Text.Json` dependency to simplify the codebase.
- Added support for serialization of `Rule` and `RuleSet` objects.
- Made the default `Rule` object read-only.
- Added an implicit conversion from `Rule` to `RuleSet`
- Introduced unit tests to validate the default behavior and various combinations of `Authorization.Rule`. 

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
