### PR TITLE
Fix: forwarded notification from nested call no longer fails parent's ExecutionStatus

### DIFF
--- a/Pipaslot.Mediator/Middlewares/MediatorContext.cs
+++ b/Pipaslot.Mediator/Middlewares/MediatorContext.cs
@@ -147,14 +147,29 @@ public ExecutionStatus Status { get; set; } = ExecutionStatus.Succeeded;
                 Status = ExecutionStatus.Failed;
             }
 
-            if (!ContainsNotification(notification))
-            {
-                _results.Add(notification);
-            }
+            AppendNotification(notification);
         }
         else
         {
             _results.Add(result);
+        }
+    }
+
+    /// <summary>
+    /// Registers a notification forwarded from a nested/child context's own Results (used by <see cref="NotificationPropagationMiddleware"/>).
+    /// Unlike <see cref="AddResult"/>, this never mutates <see cref="Status"/> - a descendant context's already-resolved outcome
+    /// must not silently flip this context's own status; only this context's own local AddResult/AddError calls do that.
+    /// </summary>
+    internal void AddForwardedNotification(Notification notification)
+    {
+        AppendNotification(notification);
+    }
+
+    private void AppendNotification(Notification notification)
+    {
+        if (!ContainsNotification(notification))
+        {
+            _results.Add(notification);
         }
     }
 

--- a/Pipaslot.Mediator/Middlewares/NotificationPropagationMiddleware.cs
+++ b/Pipaslot.Mediator/Middlewares/NotificationPropagationMiddleware.cs
@@ -17,8 +17,13 @@ internal class NotificationPropagationMiddleware : IMediatorMiddleware
         if (context.IsNested)
         {
             var parentContext = context.ParentContexts.First();
-            var notifications = context.Results.Where(r => r is Notification n && !n.StopPropagation);
-            parentContext.AddResults(notifications);
+            var notifications = context.Results
+                .Where(r => r is Notification n && !n.StopPropagation)
+                .Cast<Notification>();
+            foreach (var notification in notifications)
+            {
+                parentContext.AddForwardedNotification(notification);
+            }
         }
     }
 }

--- a/docs/wiki/9.4.-Cookbook-and-integrations.md
+++ b/docs/wiki/9.4.-Cookbook-and-integrations.md
@@ -33,6 +33,19 @@ Register the middleware in your pipeline with `.UseNotificationReceiver()`. Inje
 }
 ```
 
+### Notification propagation across nested calls
+When a handler for [action](2.-Core-concepts-and-glossary.md#action) `A` calls `IMediator` again for a [nested](2.-Core-concepts-and-glossary.md#pipeline) action `B` (`B`'s [context](2.-Core-concepts-and-glossary.md#context) has `IsNested == true`), any `Notification` added on `B`'s context is by default copied up to `A`'s context once `B`'s pipeline finishes, so it is visible in `A`'s own `Results` — and this repeats through every level of nesting up to the root context. This forwarding happens regardless of notification type, including `Error`.
+
+Forwarding a notification does **not** affect the receiving context's own `Status`/`Success` — only a notification added directly on a context affects that context's own `Status`. So if `B` fails with an error notification and `A`'s handler never inspects `B`'s outcome, `A` still succeeds. If `A` should fail whenever `B` does, it must say so explicitly: check the `Success` returned by `Execute`/`Dispatch(B)` and call `AddError()` itself, or use `ExecuteUnhandled`/`DispatchUnhandled` and let the resulting exception propagate.
+
+Set `StopPropagation = true` on the notification (last parameter of `AddInformation()`/`AddSuccess()`/`AddWarning()`/`AddError()`, or the `Notification.StopPropagation` property) to keep it local to the context that added it, instead of forwarding it to ancestors.
+
+**Use it when** a nested action's notification is only meaningful in the context that raised it and would confuse the end user if it also showed up attached to an ancestor action's result (e.g. an internal diagnostic step within a larger batch operation).
+
+**Avoid it when** the caller (or the end client) is expected to see everything that happened during nested processing — e.g. a batch endpoint that reports a message per failed item back to the UI. Setting `StopPropagation = true` there silently drops information the caller needed.
+
+`StopPropagation` only has an effect on notifications added from a nested context — it is a no-op for a notification added directly on the root context, since there is no parent to withhold it from.
+
 ## Events
 From NuGet: **Pipaslot.Mediator** since version **4.2.0**
 Middleware: `ActionEventsMiddleware` with definition `.UseActionEvents()`
@@ -131,3 +144,5 @@ public class TelemetryMiddleware(TelemetryClient telemetryClient) : IMediatorMid
 
 ## See also
 - [Ready-to-use middlewares](6.1.-Ready-to-use-middlewares.md) for the middlewares these recipes build on (`.UseNotificationReceiver()`, `.UseActionEvents()`).
+- [Mediator API - Access Mediator Context from services](5.-Mediator-API.md#access-mediator-context-from-services) for `ContextStack` and how nested calls relate to each other.
+- [HTTP transport and configuration](8.-HTTP-transport-and-configuration-for-Client-Server-usage.md) for the equivalent nested-call side-effect concern at the HTTP response level.

--- a/docs/wiki/Release-notes-and-breaking-changes.md
+++ b/docs/wiki/Release-notes-and-breaking-changes.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Added `Pipaslot.Mediator.Http.IMediatorHttpResult`, letting a handler return a result applied directly to the HTTP response — see [9.3.-Custom-HTTP-responses-and-file-download.md](9.3.-Custom-HTTP-responses-and-file-download.md). Additive, non-breaking.
+* Fix: a nested action's error notification, once forwarded into an ancestor context, no longer flips that ancestor's own ExecutionStatus/Success — see [Notification propagation across nested calls](9.4.-Cookbook-and-integrations.md#notification-propagation-across-nested-calls).
 
 ## Version 8.4.0
 * Added `MediatorContext.Depth` and `MediatorContext.IsNested` to expose the nesting level of the current execution (1 = root execution, `IsNested` true when `Depth > 1`).

--- a/tests/Pipaslot.Mediator.Tests/Notifications/NotificationPropagationStatusTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Notifications/NotificationPropagationStatusTests.cs
@@ -1,0 +1,143 @@
+﻿using Pipaslot.Mediator.Abstractions;
+using Pipaslot.Mediator.Middlewares;
+using Pipaslot.Mediator.Notifications;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pipaslot.Mediator.Tests.Notifications;
+
+/// <summary>
+/// A nested action's error <see cref="Notification"/>, once forwarded into the parent context, must not by
+/// itself flip the parent's <see cref="ExecutionStatus"/> to Failed.
+/// </summary>
+public class NotificationPropagationStatusTests
+{
+    // Depth 1 and 2 are the propagation scenario the report describes (root never touches Status/AddNotification
+    // itself; only a nested call several levels down does). Depth 0 is deliberately excluded here and covered
+    // instead by LocalErrorNotification_AtRoot_StillFailsStatus, because at depth 0 the notification is added
+    // directly on the root/only context - that is a *local* failure, not a forwarded one.
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task ForwardedErrorNotification_DoesNotFailRootStatus(int depth)
+    {
+        var sut = Factory.CreateConfiguredMediator();
+        var res = await sut.Dispatch(new ErrorNotifyingAction(depth, StopPropagation: false));
+
+        Assert.True(res.Success);
+        Assert.Contains(res.Results, r => r is Notification n && n.Type == NotificationType.Error);
+    }
+
+    [Fact]
+    public async Task LocalErrorNotification_AtRoot_StillFailsStatus()
+    {
+        var sut = Factory.CreateConfiguredMediator();
+        var res = await sut.Dispatch(new ErrorNotifyingAction(0, StopPropagation: false));
+
+        Assert.False(res.Success);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task StopPropagation_KeepsRootSucceededAndHidesNotification(int depth)
+    {
+        var sut = Factory.CreateConfiguredMediator();
+        var res = await sut.Dispatch(new ErrorNotifyingAction(depth, StopPropagation: true));
+
+        Assert.True(res.Success);
+        Assert.DoesNotContain(res.Results, r => r is Notification);
+    }
+
+    [Fact]
+    public async Task ParentExplicitlyReactingToNestedFailure_CanStillFailItself()
+    {
+        var sut = Factory.CreateConfiguredMediator();
+        var res = await sut.Dispatch(new ReactingParentAction());
+
+        Assert.False(res.Success);
+        Assert.Contains(res.Results, r => r is Notification n && n.Content.Contains("explicitly failing"));
+    }
+
+    [Fact]
+    public async Task DispatchUnhandled_StillThrowsForItsOwnLocalError()
+    {
+        var sut = Factory.CreateConfiguredMediator();
+
+        await Assert.ThrowsAsync<MediatorExecutionException>(async () =>
+            await sut.DispatchUnhandled(new ErrorNotifyingAction(0, StopPropagation: false)));
+    }
+
+    [Theory]
+    [InlineData(NotificationType.Success, 0)]
+    [InlineData(NotificationType.Information, 0)]
+    [InlineData(NotificationType.Warning, 0)]
+    [InlineData(NotificationType.Success, 1)]
+    [InlineData(NotificationType.Information, 1)]
+    [InlineData(NotificationType.Warning, 1)]
+    public async Task NonErrorNotificationTypes_NeverFailStatus(NotificationType type, int depth)
+    {
+        var sut = Factory.CreateConfiguredMediator();
+        var res = await sut.Dispatch(new TypedNotifyingAction(depth, type));
+
+        Assert.True(res.Success);
+    }
+
+    /// <summary>
+    /// Recurses <paramref name="Depth"/> times before adding an error notification, reproducing
+    /// Todos/1.3's <c>ErrorNotifyingAction</c>/<c>Handler</c> pair.
+    /// </summary>
+    private record ErrorNotifyingAction(int Depth, bool StopPropagation) : IMediatorAction;
+
+    private record ErrorNotifyingActionHandler(IMediatorFacade Facade) : IMediatorHandler<ErrorNotifyingAction>
+    {
+        public async Task Handle(ErrorNotifyingAction action, CancellationToken cancellationToken)
+        {
+            if (action.Depth > 0)
+            {
+                await Facade.Dispatch(action with { Depth = action.Depth - 1 }, cancellationToken);
+            }
+            else
+            {
+                Facade.AddNotification(new Notification
+                {
+                    Content = "boom", Type = NotificationType.Error, StopPropagation = action.StopPropagation
+                });
+            }
+        }
+    }
+
+    private record ReactingParentAction : IMediatorAction;
+
+    private record ReactingParentActionHandler(IMediatorFacade Facade) : IMediatorHandler<ReactingParentAction>
+    {
+        public async Task Handle(ReactingParentAction action, CancellationToken cancellationToken)
+        {
+            // StopPropagation:true isolates the mechanism under test: the parent's failure must come only from
+            // its own explicit AddError below, not from the nested notification also auto-propagating.
+            var nestedResult = await Facade.Dispatch(new ErrorNotifyingAction(0, StopPropagation: true), cancellationToken);
+            if (!nestedResult.Success)
+            {
+                Facade.Context!.AddError("Parent explicitly failing because a nested action failed");
+            }
+        }
+    }
+
+    private record TypedNotifyingAction(int Depth, NotificationType Type) : IMediatorAction;
+
+    private record TypedNotifyingActionHandler(IMediatorFacade Facade) : IMediatorHandler<TypedNotifyingAction>
+    {
+        public async Task Handle(TypedNotifyingAction action, CancellationToken cancellationToken)
+        {
+            if (action.Depth > 0)
+            {
+                await Facade.Dispatch(action with { Depth = action.Depth - 1 }, cancellationToken);
+            }
+            else
+            {
+                Facade.AddNotification(new Notification { Content = "note", Type = action.Type });
+            }
+        }
+    }
+}

--- a/tests/Pipaslot.Mediator.Tests/Notifications/NotificationPropagationTests.cs
+++ b/tests/Pipaslot.Mediator.Tests/Notifications/NotificationPropagationTests.cs
@@ -52,11 +52,20 @@ public class NotificationPropagationTests
     [InlineData(ServiceType.Facade, 1, true, false, false)]
     [InlineData(ServiceType.Facade, 2, true, true, false)]
     [InlineData(ServiceType.Facade, 2, true, false, false)]
+    // Results-forwarding must not depend on the notification type: an Error notification propagates through
+    // Results exactly like a Success one (see NotificationPropagationStatusTests for the separate concern of
+    // whether it also flips the parent's Status).
+    [InlineData(ServiceType.Facade, 0, false, true, true, NotificationType.Error)]
+    [InlineData(ServiceType.Facade, 0, false, false, true, NotificationType.Error)]
+    [InlineData(ServiceType.Facade, 1, false, true, false, NotificationType.Error)]
+    [InlineData(ServiceType.Facade, 1, false, false, true, NotificationType.Error)]
+    [InlineData(ServiceType.Facade, 2, false, true, false, NotificationType.Error)]
+    [InlineData(ServiceType.Facade, 2, false, false, true, NotificationType.Error)]
     public async Task TestPropagation(ServiceType serviceType, int depth, bool cancelPropagationByMiddleware, bool stopPropagation,
-        bool shouldHaveNotification)
+        bool shouldHaveNotification, NotificationType type = NotificationType.Success)
     {
         var sut = Factory.CreateConfiguredMediator(c => c.Use<StopPropagationMiddleware>());
-        var res = await sut.Dispatch(new NotifyingAction(depth, stopPropagation, serviceType, cancelPropagationByMiddleware));
+        var res = await sut.Dispatch(new NotifyingAction(depth, stopPropagation, serviceType, cancelPropagationByMiddleware, type));
         var notifications = res.Results.Where(r => r is Notification).Cast<Notification>().ToList();
         if (shouldHaveNotification)
         {
@@ -68,7 +77,8 @@ public class NotificationPropagationTests
         }
     }
 
-    private record NotifyingAction(int Depth, bool StopPropagation, ServiceType ServiceType, bool CancelPropagationByMiddleware) : IMediatorAction;
+    private record NotifyingAction(int Depth, bool StopPropagation, ServiceType ServiceType, bool CancelPropagationByMiddleware,
+        NotificationType Type = NotificationType.Success) : IMediatorAction;
 
     private record NotifyingActionHandler : IMediatorHandler<NotifyingAction>
     {
@@ -93,7 +103,7 @@ public class NotificationPropagationTests
             {
                 var notifiaction = new Notification
                 {
-                    Content = NotificationContent, Type = NotificationType.Success, StopPropagation = action.StopPropagation
+                    Content = NotificationContent, Type = action.Type, StopPropagation = action.StopPropagation
                 };
                 if (action.ServiceType == ServiceType.NotificationProvider)
                 {


### PR DESCRIPTION
**Summary**
- A forwarded error `Notification` from a nested mediator call was incorrectly flipping the parent context's `Status`/`Success`, even when the parent handler never inspected the nested call's outcome.
- `NotificationPropagationMiddleware` now copies forwarded notifications via a new path (`MediatorContext.AddForwardedNotification`) that only appends to `Results`, without mutating `Status` — `AddResult` is unchanged for locally added notifications.
- `AddError`, `AddNotification`, and `MediatorContext.AddResult` keep their exact current behavior — a local error on a handler's own context still sets `Status = Failed`.
- Added a changelog entry under `## Unreleased`; the wiki already documented the intended behavior.

**Why**
A parent handler that just re-dispatches a nested action, without checking its result, had no way to know its own `Status` got silently failed by the nested call's error — no exception, no explicit check. The intended contract: a parent only fails explicitly, either via `*Unhandled` throwing or by checking `response.Success` and calling `AddError` itself.