### PR TITLE
Add response status code hint API to replace direct HttpContext writes

### DIFF
--- a/Demo/Server/MediatorMiddlewares/ValidatorMiddleware.cs
+++ b/Demo/Server/MediatorMiddlewares/ValidatorMiddleware.cs
@@ -1,10 +1,11 @@
 ﻿using Demo.Shared;
 using Pipaslot.Mediator.Middlewares;
 using System.Net;
+using Pipaslot.Mediator.Http;
 
 namespace Demo.Server.MediatorMiddlewares;
 
-public class ValidatorMiddleware(IHttpContextAccessor httpContextAccessor) : IMediatorMiddleware
+public class ValidatorMiddleware : IMediatorMiddleware
 {
     public async Task Invoke(MediatorContext context, MiddlewareDelegate next)
     {
@@ -14,14 +15,8 @@ public class ValidatorMiddleware(IHttpContextAccessor httpContextAccessor) : IMe
             if (errors != null && errors.Any())
             {
                 context.AddErrors(errors);
-                // Optional:
-                // Notify the client via response status code to imporove logging and debugging experience
-                var httpContext = httpContextAccessor.HttpContext;
-                if (httpContext != null)
-                {
-                    httpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                }
-
+                context.SetResponseStatusCodeHint((int)HttpStatusCode.BadRequest);
+               
                 return;
             }
         }

--- a/Pipaslot.Mediator.Http/MediatorContextExtensions.cs
+++ b/Pipaslot.Mediator.Http/MediatorContextExtensions.cs
@@ -1,0 +1,32 @@
+using Pipaslot.Mediator.Middlewares;
+
+namespace Pipaslot.Mediator.Http;
+
+public static class MediatorContextExtensions
+{
+    /// <summary>
+    /// Hints the HTTP status code that <see cref="MediatorMiddleware"/> should apply to the root HTTP response,
+    /// instead of a middleware/handler writing to <c>HttpContext.Response.StatusCode</c> directly.
+    /// <para>
+    /// No-op when <paramref name="context"/> is nested (<see cref="MediatorContext.IsNested"/> is <c>true</c>): a
+    /// nested mediator call does not own the root HTTP response, so the hint would only take effect if the calling
+    /// handler explicitly forwarded it - not a supported pattern for this API. Only call this from a
+    /// middleware/handler that is running for the root action.
+    /// </para>
+    /// <para>
+    /// Takes precedence over <see cref="Configuration.ServerMediatorOptions.ErrorHttpStatusCode"/>, but yields to an
+    /// <see cref="IMediatorHttpResult"/> present in the root Results - see <see cref="MediatorMiddleware"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="context">Context of the currently processed action.</param>
+    /// <param name="statusCode">HTTP status code to apply to the root response, e.g. 400 for a validation error.</param>
+    public static void SetResponseStatusCodeHint(this MediatorContext context, int statusCode)
+    {
+        if (context.IsNested)
+        {
+            return;
+        }
+
+        context.AddResult(new ResponseStatusCodeHint(statusCode));
+    }
+}

--- a/Pipaslot.Mediator.Http/MediatorMiddleware.cs
+++ b/Pipaslot.Mediator.Http/MediatorMiddleware.cs
@@ -40,15 +40,25 @@ public class MediatorMiddleware(RequestDelegate next, ServerMediatorOptions opti
                 return;
             }
 
+            // A later hint overrides an earlier one, same as MediatorContext.Features.Set would.
+            var statusCodeHint = mediatorResponse.Results.OfType<ResponseStatusCodeHint>().LastOrDefault();
+            if (statusCodeHint is not null && !context.Response.HasStarted)
+            {
+                context.Response.StatusCode = statusCodeHint.StatusCode;
+            }
             // Change status code only if has default value (200: OK)
-            if (context.Response.StatusCode == (int)HttpStatusCode.OK && mediatorResponse.Failure)
+            else if (context.Response.StatusCode == (int)HttpStatusCode.OK && mediatorResponse.Failure)
             {
                 context.Response.StatusCode = option.ErrorHttpStatusCode;
             }
 
             if (!context.Response.HasStarted)
             {
-                var serializedResponse = serializer.SerializeResponse(mediatorResponse);
+                // The hint is an internal signal for the status code only - never part of the serialized JSON body.
+                var bodyResponse = statusCodeHint is null
+                    ? mediatorResponse
+                    : new MediatorResponse(mediatorResponse.Success, mediatorResponse.Results.Where(r => r is not ResponseStatusCodeHint));
+                var serializedResponse = serializer.SerializeResponse(bodyResponse);
                 context.Response.ContentType = "application/json; charset=utf-8";
                 await context.Response.WriteAsync(serializedResponse).ConfigureAwait(false);
             }

--- a/Pipaslot.Mediator.Http/ResponseStatusCodeHint.cs
+++ b/Pipaslot.Mediator.Http/ResponseStatusCodeHint.cs
@@ -1,0 +1,20 @@
+namespace Pipaslot.Mediator.Http;
+
+/// <summary>
+/// Marker added to the root action's <see cref="Pipaslot.Mediator.Middlewares.MediatorContext.Results"/> via
+/// <see cref="MediatorContextExtensions.SetResponseStatusCodeHint"/> to let a middleware or handler influence the
+/// HTTP status code of the root response without touching <c>HttpContext</c> directly.
+/// <para>
+/// Only read by <see cref="MediatorMiddleware"/>, from the root action's Results, and is always stripped out
+/// before the default JSON response body is serialized - it never appears on the wire.
+/// </para>
+/// <para>
+/// Like <see cref="IMediatorHttpResult"/>, a hint added on a nested <see cref="Pipaslot.Mediator.Middlewares.MediatorContext"/>
+/// stays trapped in that context's own Results and is discarded once the nested call returns - it never leaks into
+/// the root response unless the calling handler explicitly forwards it, which is not a supported pattern here.
+/// </para>
+/// </summary>
+internal sealed class ResponseStatusCodeHint(int statusCode)
+{
+    public int StatusCode { get; } = statusCode;
+}

--- a/docs/wiki/8.-HTTP-transport-and-configuration-for-Client-Server-usage.md
+++ b/docs/wiki/8.-HTTP-transport-and-configuration-for-Client-Server-usage.md
@@ -79,6 +79,8 @@ services.AddMediatorServer(o =>
 **IMPORTANT:** [Mediator](2.-Core-concepts-and-glossary.md#mediator) catches all exceptions that occur during middleware or action handler execution. If you have registered ASP.NET Core middleware processing uncaught exceptions, then exceptions from the mediator will never be propagated to this ASP.NET Core middleware. If you want to process all these uncaught exceptions and, for example, notify the administrator, you have to implement your own Mediator middleware and put it at the beginning of all your pipelines.
 
 **NOTE:** Since version 5.0, you can use IHttpContextAccessor and set the response HTTP status code directly in your middleware to provide a better logging or debugging experience. For example, you can set status 400 (Bad Request) in case of validation errors.
+**Prefer `SetResponseStatusCodeHint` instead** - see [Server: choosing the HTTP status code](#server-choosing-the-http-status-code) below.
+
 ### Error handling
 When called via [`Dispatch`/`Execute`](5.-Mediator-API.md#execute-or-dispatch-action-with-a-status-response) (which is what the HTTP client and server always use internally), exceptions thrown by a handler or by any middleware in the pipeline never propagate to the caller as .NET exceptions. The [Mediator](2.-Core-concepts-and-glossary.md#mediator) catches them, converts them into an error [Notification](2.-Core-concepts-and-glossary.md#notification) added to the [Response](2.-Core-concepts-and-glossary.md#response), and marks the response as failed (`Success = false`). This happens identically for in-process and HTTP usage, so a handler never needs to know whether it is being called locally or over HTTP.
 
@@ -87,30 +89,53 @@ Note that [Mediator](2.-Core-concepts-and-glossary.md#mediator) also exposes [`D
 The subsections below spell out exactly how this plays out for the server (status codes, logging) and the client (how a failure surfaces to your calling code), each with a copyable middleware recipe.
 
 #### Server: choosing the HTTP status code
-When `MediatorMiddleware` writes the response, it checks the HTTP status code that is already set:
-- If it is still the default 200 (OK) and the mediator response failed, it is replaced with `ServerMediatorOptions.ErrorHttpStatusCode` (500 by default).
-- If a middleware already changed the status code (e.g. to signal a validation error), that value is preserved and `ErrorHttpStatusCode` is **not** applied.
+When `MediatorMiddleware` writes the response, it resolves the status code in this order:
+1. If `Pipaslot.Mediator.Http.IMediatorHttpResult` is present in the root [action](2.-Core-concepts-and-glossary.md#action)'s [Results](2.-Core-concepts-and-glossary.md#result), that result owns the whole response and any status code hint is ignored - see [Custom HTTP responses and file download](9.3.-Custom-HTTP-responses-and-file-download.md).
+2. Otherwise, if a status code hint was set via `SetResponseStatusCodeHint` (see below) and the response has not started yet, that status code is applied.
+3. Otherwise, if the status code is still the default 200 (OK) and the mediator response failed, it is replaced with `ServerMediatorOptions.ErrorHttpStatusCode` (500 by default).
 
-This lets you assign a more specific status code from within your own middleware, using `IHttpContextAccessor`:
+##### Recommended: `SetResponseStatusCodeHint`
+A middleware or handler running for the root action can hint a specific status code (e.g. 400 for a validation error) without touching `HttpContext` directly, via `Pipaslot.Mediator.Http.MediatorContextExtensions.SetResponseStatusCodeHint`:
+```csharp
+public class ValidatorMiddleware : IMediatorMiddleware
+{
+    public async Task Invoke(MediatorContext context, MiddlewareDelegate next)
+    {
+        var errors = validable.Validate();
+        if (errors != null && errors.Any())
+        {
+            context.AddErrors(errors);
+            // Notify the client via response status code to improve logging and debugging experience
+            context.SetResponseStatusCodeHint((int)HttpStatusCode.BadRequest);
+            return; // Short-circuit the pipeline - the handler is not executed 
+        }
+        await next(context);
+    }
+}
+```
+This is why the hint is preferred over writing to `HttpContext.Response.StatusCode` directly: the middleware stays transport-agnostic, with no `IHttpContextAccessor` dependency and no manual root-vs-nested check. Calling `SetResponseStatusCodeHint` while [nested](5.-Mediator-API.md#access-mediator-context-from-services) (`context.IsNested` is `true`) is a no-op - a nested call does not own the root HTTP response, so a hint it sets is simply dropped rather than silently overwriting the status code of the actual root action's response. If more than one hint is set for the same root action, the last one wins, the same way `context.Features.Set(...)` would overwrite an earlier value.
+
+##### Alternative: writing to `HttpContext.Response.StatusCode` directly
+You can still use `IHttpContextAccessor` and set the response HTTP status code directly in your middleware. This gives you low-level control, but you lose the safety `SetResponseStatusCodeHint` gives you for nested calls - you have to guard it yourself, the same way [Custom HTTP responses and file download](9.3.-Custom-HTTP-responses-and-file-download.md#alternative-writing-to-httpcontextresponse-directly) documents for writing the response body directly:
 ```csharp
 public class ValidatorMiddleware(IHttpContextAccessor httpContextAccessor) : IMediatorMiddleware
 {
     public async Task Invoke(MediatorContext context, MiddlewareDelegate next)
     {
-        if (context.Action is IValidable validable)
+        var errors = validable.Validate();
+        if (errors != null && errors.Any())
         {
-            var errors = validable.Validate();
-            if (errors != null && errors.Any())
+            context.AddErrors(errors);
+            if (!context.IsNested)
             {
-                context.AddErrors(errors);
                 // Notify the client via response status code to improve logging and debugging experience
                 var httpContext = httpContextAccessor.HttpContext;
                 if (httpContext != null)
                 {
                     httpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
                 }
-                return; // Short-circuit the pipeline - the handler is not executed
             }
+            return; // Short-circuit the pipeline - the handler is not executed
         }
         await next(context);
     }

--- a/docs/wiki/Release-notes-and-breaking-changes.md
+++ b/docs/wiki/Release-notes-and-breaking-changes.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Added `Pipaslot.Mediator.Http.IMediatorHttpResult`, letting a handler return a result applied directly to the HTTP response — see [9.3.-Custom-HTTP-responses-and-file-download.md](9.3.-Custom-HTTP-responses-and-file-download.md). Additive, non-breaking.
+* Added `Pipaslot.Mediator.Http.MediatorContextExtensions.SetResponseStatusCodeHint`, letting a middleware or handler hint the root HTTP response status code without touching `HttpContext` directly — see [8.-HTTP-transport-and-configuration-for-Client-Server-usage.md](8.-HTTP-transport-and-configuration-for-Client-Server-usage.md#server-choosing-the-http-status-code). Additive, non-breaking.
 
 ## Version 8.4.0
 * Added `MediatorContext.Depth` and `MediatorContext.IsNested` to expose the nesting level of the current execution (1 = root execution, `IsNested` true when `Depth > 1`).

--- a/tests/Pipaslot.Mediator.Http.Tests/MediatorMiddlewareTests.cs
+++ b/tests/Pipaslot.Mediator.Http.Tests/MediatorMiddlewareTests.cs
@@ -2,9 +2,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Pipaslot.Mediator.Abstractions;
+using Pipaslot.Mediator.Http.Serialization;
 using Pipaslot.Mediator.Http.Tests.Fakes;
 using Pipaslot.Mediator.Tests.ValidActions;
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -149,6 +151,120 @@ public class MediatorMiddlewareTests
         Assert.False(second.Applied);
     }
 
+    [Fact]
+    public async Task WillApplyStatusCodeHint_WhenPresent()
+    {
+        var mediatorResponse = Task.FromResult((IMediatorResponse)new MediatorResponse(true, [new ResponseStatusCodeHint(400)]));
+        var mediatorMock = new Mock<IMediator>();
+        mediatorMock.Setup(x => x.Dispatch(It.IsAny<IMediatorAction>(), It.IsAny<CancellationToken>())).Returns(mediatorResponse);
+        var services = CreateServiceProvider(mediatorMock);
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse();
+        var context = new FakeContext(new FakePostRequest(_message), services, response);
+        await sut.Invoke(context);
+
+        Assert.Equal(400, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WillOverwriteAlreadySetStatusCode_WhenHintPresent()
+    {
+        // A hint always wins over whatever a legacy middleware already wrote directly to HttpContext.Response.
+        var mediatorResponse = Task.FromResult((IMediatorResponse)new MediatorResponse(false, [new ResponseStatusCodeHint(409)]));
+        var mediatorMock = new Mock<IMediator>();
+        mediatorMock.Setup(x => x.Dispatch(It.IsAny<IMediatorAction>(), It.IsAny<CancellationToken>())).Returns(mediatorResponse);
+        var services = CreateServiceProvider(mediatorMock);
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse { StatusCode = (int)HttpStatusCode.BadRequest };
+        var context = new FakeContext(new FakePostRequest(_message), services, response);
+        await sut.Invoke(context);
+
+        Assert.Equal(409, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WillUseLastStatusCodeHint_WhenMultiplePresent()
+    {
+        // A later hint overrides an earlier one, mirroring what MediatorContext.Features.Set() would do.
+        var mediatorResponse = Task.FromResult((IMediatorResponse)new MediatorResponse(true,
+            [new ResponseStatusCodeHint(400), new ResponseStatusCodeHint(409)]));
+        var mediatorMock = new Mock<IMediator>();
+        mediatorMock.Setup(x => x.Dispatch(It.IsAny<IMediatorAction>(), It.IsAny<CancellationToken>())).Returns(mediatorResponse);
+        var services = CreateServiceProvider(mediatorMock);
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse();
+        var context = new FakeContext(new FakePostRequest(_message), services, response);
+        await sut.Invoke(context);
+
+        Assert.Equal(409, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WillNotApplyStatusCodeHint_WhenResponseAlreadyStarted()
+    {
+        var mediatorResponse = Task.FromResult((IMediatorResponse)new MediatorResponse(true, [new ResponseStatusCodeHint(400)]));
+        var mediatorMock = new Mock<IMediator>();
+        mediatorMock.Setup(x => x.Dispatch(It.IsAny<IMediatorAction>(), It.IsAny<CancellationToken>())).Returns(mediatorResponse);
+        var services = CreateServiceProvider(mediatorMock);
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse(hasStarted: true);
+        var context = new FakeContext(new FakePostRequest(_message), services, response);
+        await sut.Invoke(context);
+
+        Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
+        // Default JSON serialization must also be skipped once something else already wrote to the response
+        Assert.Equal(string.Empty, response.ContentType);
+    }
+
+    [Fact]
+    public async Task WillIgnoreStatusCodeHint_WhenHttpResultPresent()
+    {
+        // IMediatorHttpResult owns the whole response and takes precedence over a mere status-code annotation.
+        var httpResult = new FakeHttpResult();
+        var mediatorResponse = Task.FromResult((IMediatorResponse)new MediatorResponse(true, [httpResult, new ResponseStatusCodeHint(400)]));
+        var mediatorMock = new Mock<IMediator>();
+        mediatorMock.Setup(x => x.Dispatch(It.IsAny<IMediatorAction>(), It.IsAny<CancellationToken>())).Returns(mediatorResponse);
+        var services = CreateServiceProvider(mediatorMock);
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse();
+        var context = new FakeContext(new FakePostRequest(_message), services, response);
+        await sut.Invoke(context);
+
+        Assert.True(httpResult.Applied);
+        Assert.Equal((int)HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WillExcludeStatusCodeHint_FromSerializedResponseBody()
+    {
+        const string otherResult = "actual-result";
+        var mediatorResponse = Task.FromResult((IMediatorResponse)new MediatorResponse(true, [otherResult, new ResponseStatusCodeHint(400)]));
+        var mediatorMock = new Mock<IMediator>();
+        mediatorMock.Setup(x => x.Dispatch(It.IsAny<IMediatorAction>(), It.IsAny<CancellationToken>())).Returns(mediatorResponse);
+
+        IMediatorResponse? serialized = null;
+        var serializerMock = new Mock<IContractSerializer>();
+        serializerMock.Setup(x => x.SerializeResponse(It.IsAny<IMediatorResponse>()))
+            .Callback<IMediatorResponse>(r => serialized = r)
+            .Returns("{}");
+
+        var services = CreateServiceProvider(mediatorMock, serializerMock);
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse();
+        var context = new FakeContext(new FakePostRequest(_message), services, response);
+        await sut.Invoke(context);
+
+        Assert.NotNull(serialized);
+        Assert.DoesNotContain(serialized!.Results, r => r is ResponseStatusCodeHint);
+        Assert.Contains(otherResult, serialized.Results);
+    }
+
     private async Task ExecuteRequest(HttpRequest request)
     {
         var mediatorResponse = Task.FromResult((IMediatorResponse<string>)new MediatorResponse<string>(true, Array.Empty<object>()));
@@ -178,7 +294,7 @@ public class MediatorMiddlewareTests
         mediatorMock.Verify(m => m.Dispatch(It.IsAny<NopMessage>(), It.IsAny<CancellationToken>()));
     }
 
-    private ServiceProvider CreateServiceProvider(Mock<IMediator> mediatorMock)
+    private ServiceProvider CreateServiceProvider(Mock<IMediator> mediatorMock, Mock<IContractSerializer>? serializerMock = null)
     {
         var collection = new ServiceCollection();
         collection.AddLogging();
@@ -187,6 +303,10 @@ public class MediatorMiddlewareTests
         collection.AddScoped<MediatorMiddleware>();
         collection.AddScoped<RequestDelegate>(s => (c) => Task.CompletedTask);
         collection.AddSingleton<IMediator>(mediatorMock.Object);
+        if (serializerMock is not null)
+        {
+            collection.AddSingleton(serializerMock.Object);
+        }
         return collection.BuildServiceProvider();
     }
 }

--- a/tests/Pipaslot.Mediator.Http.Tests/MediatorMiddleware_NestedStatusCodeHintTests.cs
+++ b/tests/Pipaslot.Mediator.Http.Tests/MediatorMiddleware_NestedStatusCodeHintTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Pipaslot.Mediator.Abstractions;
+using Pipaslot.Mediator.Http.Tests.Fakes;
+using Pipaslot.Mediator.Middlewares;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Pipaslot.Mediator.Http.Tests;
+
+/// <summary>
+/// End-to-end regression coverage for the structural claim behind
+/// <see cref="MediatorContextExtensions.SetResponseStatusCodeHint"/>: a hint set on a nested
+/// <see cref="MediatorContext"/> (<see cref="MediatorContext.IsNested"/> is <c>true</c>) never leaks into the root
+/// HTTP response - it is dropped at the point it would be set, mirroring the "root vs. nested" safety
+/// <see cref="IMediatorHttpResult"/> already gives for full response bodies.
+/// </summary>
+public class MediatorMiddleware_NestedStatusCodeHintTests
+{
+    private const string _parentRequest =
+        "{\"$type\":\"Pipaslot.Mediator.Http.Tests.StatusHintParentAction, Pipaslot.Mediator.Http.Tests\"}";
+
+    [Fact]
+    public async Task WillApplyRootHint_AndIgnoreHintSetByNestedCall()
+    {
+        var services = CreateServiceProvider();
+        var sut = services.GetRequiredService<MediatorMiddleware>();
+
+        var response = new FakeResponse();
+        var context = new FakeContext(new FakePostRequest(_parentRequest), services, response);
+        await sut.Invoke(context);
+
+        // Root middleware hints 201; the nested child action also hints (409), but that call is nested
+        // (Depth > 1), so its hint must never reach the root HTTP response.
+        Assert.Equal(201, response.StatusCode);
+    }
+
+    private static IServiceProvider CreateServiceProvider()
+    {
+        var collection = new ServiceCollection();
+        collection.AddLogging();
+        collection.AddMediatorServer(o => o.DeserializeOnlyCredibleActionTypes = false)
+            .AddActions([typeof(StatusHintParentAction), typeof(StatusHintChildAction)])
+            .AddHandlers([typeof(StatusHintParentActionHandler), typeof(StatusHintChildActionHandler)])
+            .Use<StatusHintMiddleware>();
+        collection.AddScoped<MediatorMiddleware>();
+        collection.AddScoped<RequestDelegate>(_ => _ => Task.CompletedTask);
+        return collection.BuildServiceProvider();
+    }
+}
+
+internal class StatusHintParentAction : IMessage;
+
+internal class StatusHintParentActionHandler(IMediator mediator) : IMessageHandler<StatusHintParentAction>
+{
+    public Task Handle(StatusHintParentAction action, CancellationToken cancellationToken)
+    {
+        return mediator.DispatchUnhandled(new StatusHintChildAction(), cancellationToken);
+    }
+}
+
+internal class StatusHintChildAction : IMessage;
+
+internal class StatusHintChildActionHandler : IMessageHandler<StatusHintChildAction>
+{
+    public Task Handle(StatusHintChildAction action, CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Stands in for a validation-style middleware (e.g. the <c>ValidationMediatorMiddleware</c> anti-pattern this
+/// feature replaces) that hints a status code for every action it sees, regardless of nesting.
+/// </summary>
+internal class StatusHintMiddleware : IMediatorMiddleware
+{
+    public Task Invoke(MediatorContext context, MiddlewareDelegate next)
+    {
+        switch (context.Action)
+        {
+            case StatusHintParentAction:
+                context.SetResponseStatusCodeHint(201);
+                break;
+            case StatusHintChildAction:
+                context.SetResponseStatusCodeHint(409);
+                break;
+        }
+
+        return next(context);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Pipaslot.Mediator.Http.MediatorContextExtensions.SetResponseStatusCodeHint(int)`, letting a middleware or handler hint the root HTTP response status code (e.g. 400 on validation failure) without depending on `IHttpContextAccessor` or touching `HttpContext` directly.
- Fixes the same "root vs. nested" leak class that `IMediatorHttpResult` already fixed for response bodies: a hint set during a nested mediator call is silently dropped instead of overwriting the status code of the actual root HTTP response.
- `IMediatorHttpResult` still takes precedence over the hint when both are present; a later hint overrides an earlier one (last write wins).
- Updates `Demo/Server/MediatorMiddlewares/ValidatorMiddleware.cs` to use the new API instead of writing to `HttpContext.Response.StatusCode` via `IHttpContextAccessor`.
- Updates the wiki (`8.-HTTP-transport-and-configuration-for-Client-Server-usage.md`) to recommend the new hint API, keeping the direct-`HttpContext`-write pattern documented as a guarded alternative, and adds an `Unreleased` changelog entry.

## Why
Middleware that writes `HttpContext.Response.StatusCode` directly has no way to know whether it's running for the root HTTP action or a nested mediator call — a nested call unconditionally overwriting the status code silently corrupts the response meant for the real root action. The hint mechanism carries the value through `MediatorContext.Results` (the same channel `IMediatorHttpResult` uses), so it structurally cannot leak out of a nested call, and is filtered out of the serialized JSON body before it reaches the client.